### PR TITLE
Optimize SamplePartitioner for DumpAndRestore & align CountDocuments timeout

### DIFF
--- a/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
@@ -118,7 +118,7 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
         {
             FilterDefinition<BsonDocument>? userFilter = GetFilterDoc(mu.UserFilter);
             var filter = userFilter ?? Builders<BsonDocument>.Filter.Empty;
-            return collection.CountDocuments(filter);
+            return collection.CountDocuments(filter, new CountOptions { MaxTime = TimeSpan.FromMinutes(10) });
         }
 
 		/// <summary>

--- a/OnlineMongoMigrationProcessor/Partitioner/SamplePartitioner.cs
+++ b/OnlineMongoMigrationProcessor/Partitioner/SamplePartitioner.cs
@@ -150,12 +150,10 @@ namespace OnlineMongoMigrationProcessor
                     // DumpAndRestore: oversample then pick equidistant quantile boundaries
                     chunkCount = Math.Max(1, (int)Math.Ceiling((double)docCountByType / minDocsPerChunk));
                     segmentCount = 1;
+                    adjustedMaxSamples = (int)Math.Min((long)Math.Floor(docCountByType * 0.04), 500000);
 
-                    // Oversample ~200 per chunk, cap at 4% of doc count and hard cap
-                    long estimatedAvgObjSize = docCountByType > 0 ? Math.Max(1, minDocsPerChunk > 0 ? minDocsPerChunk : 1024) : 1024;
-                    sampleCount = (int)Math.Min(
-                        (long)chunkCount * 200,
-                        Math.Min((long)Math.Floor(docCountByType * 0.04), adjustedMaxSamples));
+                    // Oversample ~200 per chunk, capped by adjustedMaxSamples
+                    sampleCount = (int)Math.Min((long)chunkCount * 200, adjustedMaxSamples);
                     sampleCount = Math.Max(sampleCount, chunkCount); // at least chunkCount samples
 
                     MigrationJobContext.AddVerboseLog($"SamplePartitioner DumpAndRestore: collection={collection.CollectionNamespace}, dataType={dataType}, chunkCount={chunkCount}, sampleCount={sampleCount}");

--- a/OnlineMongoMigrationProcessor/Partitioner/SamplePartitioner.cs
+++ b/OnlineMongoMigrationProcessor/Partitioner/SamplePartitioner.cs
@@ -345,7 +345,7 @@ namespace OnlineMongoMigrationProcessor
             if (optimizeForMongoDump && partitionValues.Count > chunkCount)
             {
                 var quantileBoundaries = new List<BsonValue>();
-                for (int k = 1; k < chunkCount; k++)
+                for (int k = 0; k < chunkCount; k++)
                 {
                     int idx = (int)((long)k * partitionValues.Count / chunkCount);
                     quantileBoundaries.Add(partitionValues[idx]);

--- a/OnlineMongoMigrationProcessor/Partitioner/SamplePartitioner.cs
+++ b/OnlineMongoMigrationProcessor/Partitioner/SamplePartitioner.cs
@@ -143,62 +143,48 @@ namespace OnlineMongoMigrationProcessor
                     }
                 }
 
-                if (chunkCount > adjustedMaxSamples)
-                {
-                    int count = 2;
-                    long newCount = docCountByType / ((long)minDocsPerSegment * count);
-                    while (newCount > adjustedMaxSamples)
-                    {
-                        count++;
-
-                        // Check for potential overflow before multiplication
-                        long multiplier = (long)minDocsPerSegment * count;
-                        if (multiplier <= 0 || multiplier > docCountByType)
-                        {                           
-                            break;
-                        }
-                        newCount = docCountByType / multiplier;
-                        MigrationJobContext.AddVerboseLog($"SamplePartitioner.Calculating adjustedMaxSamples: collection={collection.CollectionNamespace}, newCount={newCount}, dataType={dataType}, docCountByType={docCountByType}, multiplier={multiplier}");
-                    }
-                    
-
-                    log.WriteLine($"Requested chunk count {chunkCount} exceeds maximum samples {adjustedMaxSamples} for {collection.CollectionNamespace}. Adjusting to {newCount}", LogType.Warning);
-                    chunkCount = (int)newCount;
-                }
-
-
-                // Ensure minimum documents per chunk
-                chunkCount = Math.Max(1, (int)Math.Ceiling((double)docCountByType / minDocsPerChunk));
-                docsInChunk = docCountByType / chunkCount;
-
-                // Calculate segments based on documents per chunk
-                segmentCount = Math.Min(
-                    Math.Max(1, (int)Math.Ceiling((double)docsInChunk / minDocsPerSegment)),
-                    GetMaxSegments()
-                );
-
-
-                // Calculate the total sample count
-                sampleCount = Math.Min(chunkCount * segmentCount, adjustedMaxSamples);
-
-
-                MigrationJobContext.AddVerboseLog($"SamplePartitioner.Calculating sampleCount: collection={collection.CollectionNamespace}, dataType={dataType}, segmentCount={segmentCount}, sampleCount{sampleCount}");
-
-                // Adjust segments per chunk based on the new sample count
-                segmentCount = Math.Max(1, sampleCount / chunkCount);
-
                 bool usePaginationPartitioner = dataType != DataType.ObjectId && config.NonObjectIdPartitioner == PartitionerType.UsePagination;
 
-                // Optimize for non-dump scenarios
-                if (!optimizeForMongoDump && !usePaginationPartitioner)
+                if (optimizeForMongoDump)
                 {
-                    while (chunkCount > segmentCount && segmentCount < GetMaxSegments())
+                    // DumpAndRestore: oversample then pick equidistant quantile boundaries
+                    chunkCount = Math.Max(1, (int)Math.Ceiling((double)docCountByType / minDocsPerChunk));
+                    segmentCount = 1;
+
+                    // Oversample ~200 per chunk, cap at 4% of doc count and hard cap
+                    long estimatedAvgObjSize = docCountByType > 0 ? Math.Max(1, minDocsPerChunk > 0 ? minDocsPerChunk : 1024) : 1024;
+                    sampleCount = (int)Math.Min(
+                        (long)chunkCount * 200,
+                        Math.Min((long)Math.Floor(docCountByType * 0.04), adjustedMaxSamples));
+                    sampleCount = Math.Max(sampleCount, chunkCount); // at least chunkCount samples
+
+                    MigrationJobContext.AddVerboseLog($"SamplePartitioner DumpAndRestore: collection={collection.CollectionNamespace}, dataType={dataType}, chunkCount={chunkCount}, sampleCount={sampleCount}");
+                }
+                else
+                {
+                    // MongoDriver path: compute segments for parallel writes within each chunk
+                    chunkCount = Math.Max(1, (int)Math.Ceiling((double)docCountByType / minDocsPerChunk));
+                    docsInChunk = docCountByType / chunkCount;
+
+                    segmentCount = Math.Min(
+                        Math.Max(1, (int)Math.Ceiling((double)docsInChunk / minDocsPerSegment)),
+                        GetMaxSegments()
+                    );
+
+                    sampleCount = Math.Min(chunkCount * segmentCount, adjustedMaxSamples);
+                    segmentCount = Math.Max(1, sampleCount / chunkCount);
+
+                    if (!usePaginationPartitioner)
                     {
-                        chunkCount--;
-                        segmentCount++;
+                        while (chunkCount > segmentCount && segmentCount < GetMaxSegments())
+                        {
+                            chunkCount--;
+                            segmentCount++;
+                        }
+                        chunkCount = sampleCount / segmentCount;
                     }
 
-                    chunkCount = sampleCount / segmentCount;
+                    MigrationJobContext.AddVerboseLog($"SamplePartitioner MongoDriver: collection={collection.CollectionNamespace}, dataType={dataType}, chunkCount={chunkCount}, segmentCount={segmentCount}, sampleCount={sampleCount}");
                 }
 
                 MigrationJobContext.AddVerboseLog($"SamplePartitioner.Calculating chunkCount: collection={collection.CollectionNamespace}, dataType={dataType}, chunkCount={chunkCount}");
@@ -355,6 +341,17 @@ namespace OnlineMongoMigrationProcessor
                 return null;
             }
             // Step 3: Calculate partition boundaries
+            // For DumpAndRestore: pick equidistant quantile boundaries from oversampled sorted list
+            if (optimizeForMongoDump && partitionValues.Count > chunkCount)
+            {
+                var quantileBoundaries = new List<BsonValue>();
+                for (int k = 1; k < chunkCount; k++)
+                {
+                    int idx = (int)((long)k * partitionValues.Count / chunkCount);
+                    quantileBoundaries.Add(partitionValues[idx]);
+                }
+                partitionValues = quantileBoundaries;
+            }
 
             chunkBoundaries = ConvertToBoundaries(partitionValues, segmentCount);
 


### PR DESCRIPTION
## Commits

### Commit 1: Update MaxTime for GetActualDocumentCount to keep aligned with GetDocumentCount method

**File:** `OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs`

One-line fix: `GetActualDocumentCount` was calling `collection.CountDocuments(filter)` with no timeout, while the similar `GetDocumentCountByDataType` in SamplePartitioner uses a large `MaxTime`. On large collections this could hang indefinitely.

Added `new CountOptions { MaxTime = TimeSpan.FromMinutes(10) }` to align with the timeout-based count pattern used in helper count operations.

### Commit 2: Refactor SamplePartitioner to optimize chunk and sample count calculations for MongoDB dump scenarios

**File:** `OnlineMongoMigrationProcessor/Partitioner/SamplePartitioner.cs`

#### Background

The `SamplePartitioner.CreatePartitions` method computes how many `_id` samples to take from a collection and how to convert those samples into chunk boundaries. Two concepts exist in the project:

- **Chunk**: a top-level `_id` range representing one unit of scheduled work. In DumpAndRestore mode, each chunk maps to one mongodump/mongorestore invocation.
- **Segment**: a sub-range within a chunk for parallel writes. Only used by MongoDriver mode — DumpAndRestore does not use segments.

#### Problem

The old code had a single calculation path for both DumpAndRestore and MongoDriver modes:

1. **Dead code from contradictory logic.** A `chunkCount > adjustedMaxSamples` reduction loop (old lines 145-167) would reduce `chunkCount`, but a subsequent line immediately overrode it with `chunkCount = Math.Max(1, ceil(docCountByType / minDocsPerChunk))`, discarding the reduction entirely. For large collections (e.g., 5 TB / 64 MB chunk size = 81,920 chunks), the reduction loop ran but its result was thrown away.

2. **Unnecessary segment computation for DumpAndRestore.** DumpAndRestore mode doesn't use segments (sub-ranges for parallel writes within a chunk). Yet the code computed `segmentCount`, multiplied it into `sampleCount`, then skipped the segment-balancing loop (gated by `!optimizeForMongoDump`), leaving `segmentCount` as a wasted multiplier.

3. **Poor boundary distribution.** The code sampled exactly `chunkCount` `_id` values via MongoDB's `$sample` aggregation and used each one directly as a chunk boundary. With `$sample` returning pseudo-random documents, this produced uneven chunk sizes — some chunks could be 10x larger than others.

#### Solution

**Change A — Split calculation into DumpAndRestore vs MongoDriver paths:**

| | DumpAndRestore (new) | MongoDriver (unchanged logic) |
|---|---|---|
| `chunkCount` | `ceil(docCount / minDocsPerChunk)` | Same formula |
| `segmentCount` | `1` (not used) | Computed from `docsInChunk / minDocsPerSegment`, capped at `MaxSegments` |
| `sampleCount` | `max(chunkCount, min(chunkCount × 200, floor(docCount × 0.04), 500000))` | `min(chunks × segments, adjustedMaxSamples)` |

The DumpAndRestore formula oversamples ~200 points per desired chunk, capped at 4% of total document count to stay within `$sample`'s fast pseudo-random path (MongoDB uses the fast path when `$sample` size < 5% of collection), with a hard cap at `500,000`, and floored to at least `chunkCount` samples.

**Change B — Equidistant quantile boundary selection for DumpAndRestore:**

In the general sampler path (`GetChunkBoundariesGeneral`), after `$sample` + sort produces the oversampled sorted `_id` list, instead of passing all sampled points directly to `ConvertToBoundaries`, we pick equidistant quantile anchors:

```csharp
for (int k = 0; k < chunkCount; k++)
{
    int idx = (int)((long)k * partitionValues.Count / chunkCount);
    quantileBoundaries.Add(partitionValues[idx]);
}
```

Each anchor is placed at the position where approximately `1/chunkCount` of the sampled data lies between anchors, producing more evenly distributed chunk sizes than using a minimally sized random sample.

#### Impact

- **DumpAndRestore:** More evenly sized chunks → better parallelism for mongodump/mongorestore, less skew where one worker finishes early while another is stuck on a disproportionately large chunk.
- **MongoDriver:** No behavioral change. The existing segment-based logic is preserved as-is under the `else` branch.
- **No new dependencies or configuration changes.**

---

## Testing Evidence: Oversampling + Quantile Boundary Selection

The approach was validated using a standalone MongoDB shell script against a real collection with 20 repeated chunk split tests.

### Test Collection

- **Estimated size:** ~18M documents
- **Chunk size:** 64 MB → **1,038 chunks**
- **Ideal docs per chunk:** ~17,340
- **Sample formula:** `sampleSize = max(chunks, min(chunks × 200, docCount × 0.04, 500000))` → ~207,600 samples (~200 per chunk)

### Results (20 runs, 1,038 chunks each)

> **Duration (ms)** measures only the chunk splitting time (sampling + sorting + boundary computation). The per-chunk document count validation runs separately and is excluded from the duration.

| Test | Min Chunk | P50 | P75 | Max Chunk | Duration (ms) |
|------|-----------|-----|-----|-----------|---------------|
| 1 | 2,984 | 19,038 | 23,795 | 47,250 | 2,964 |
| 2 | 937 | 18,730 | 24,850 | 70,587 | 3,288 |
| 3 | 3,317 | 18,969 | 24,154 | 53,544 | 3,731 |
| 4 | 2,594 | 18,949 | 23,966 | 57,191 | 3,285 |
| 5 | 2,621 | 18,729 | 23,785 | 53,477 | 3,944 |
| 6 | 3,031 | 19,013 | 23,966 | 55,454 | 3,268 |
| 7 | 3,793 | 18,811 | 23,661 | 51,942 | 4,427 |
| 8 | 2,498 | 18,912 | 23,869 | 66,260 | 2,863 |
| 9 | 2,889 | 18,560 | 23,978 | 67,647 | 3,034 |
| 10 | 3,115 | 18,168 | 24,423 | 59,307 | 3,049 |
| 11 | 3,291 | 18,615 | 24,455 | 49,573 | 2,747 |
| 12 | 3,325 | 18,589 | 24,302 | 61,041 | 3,759 |
| 13 | 3,619 | 18,684 | 24,339 | 50,167 | 3,180 |
| 14 | 3,086 | 18,792 | 24,276 | 48,405 | 3,153 |
| 15 | 1,607 | 18,874 | 24,546 | 76,541 | 4,189 |
| 16 | 3,606 | 18,542 | 24,254 | 61,107 | 3,996 |
| 17 | 4,693 | 18,919 | 24,178 | 61,449 | 4,646 |
| 18 | 4,454 | 18,732 | 24,071 | 59,302 | 3,510 |
| 19 | 3,568 | 18,668 | 23,886 | 49,310 | 4,000 |
| 20 | 1,816 | 18,558 | 24,395 | 58,706 | 4,842 |

### Summary (ideal per-chunk ≈ 17,340)

| Metric | Range across 20 runs | vs. Ideal |
|---|---|---|
| **P50** | 18,168 – 19,038 | **1.05–1.10x** (excellent) |
| **P75** | 23,661 – 24,850 | **1.36–1.43x** (good) |
| **Max** | 47,250 – 76,541 | **2.7–4.4x** (tail outliers) |
| **Min** | 937 – 4,693 | **5–27% of ideal** (tail outliers) |
| **Duration** | 2.7 – 4.8s | Acceptable |

### Key Design Decisions

1. **`chunks × 200` multiplier** — 200 samples per chunk provides stable quantile boundaries. Higher values (500+) showed diminishing returns at ~2x sampling duration cost.

2. **4% doc count cap + 500k hard cap** — MongoDB's `$sample` uses an efficient pseudo-random cursor when sample size < 5% of collection. Capping at 4% keeps a safety margin below this threshold, and `500,000` prevents excessive sampling on very large collections.

3. **Equidistant quantile selection** (`boundaries[k] = samples[k × N / chunks]`) — converts noisy random samples into evenly-spaced boundaries.

4. **Remaining min/max outliers are inherent to random sampling** — the first and last chunks are bounded by `minId`/`maxId` (from actual data) versus sample points, which may not align perfectly. For parallel DumpAndRestore, a 3–4x max outlier is acceptable since the vast majority of chunks are well-balanced.
