### PR TITLE
Fix upsert on sharded collections with nested shard key

### DIFF
--- a/OnlineMongoMigrationProcessor/Helpers/Mongo/AggressiveChangeStreamHelper.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/Mongo/AggressiveChangeStreamHelper.cs
@@ -435,8 +435,13 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
                     var id = doc["_id"];
                     if (id.IsObjectId)
                         id = id.AsObjectId;
-                    
-                    var filter = Builders<RawBsonDocument>.Filter.Eq("_id", id);
+
+                    // Flatten a composite (embedded) _id into dotted-path equality predicates so
+                    // sharded collections with a nested shard key (e.g. { "_id.aggregatedChallengeId": "hashed" })
+                    // can target a single shard on upsert. A whole-embedded-_id equality hides the
+                    // nested shard key from mongos and fails with
+                    // "An {upsert:true} update on a sharded collection must target a single shard".
+                    var filter = MongoHelper.BuildIdEqualityFilter<RawBsonDocument>(id);
                     return new ReplaceOneModel<RawBsonDocument>(filter, doc) { IsUpsert = true };
                 }).ToList();
 

--- a/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
@@ -1974,14 +1974,70 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
         {
             var filters = new List<FilterDefinition<BsonDocument>>();
 
-            foreach (var element in documentKey.Elements)
+            AddEqualityFiltersFromDocument(documentKey, string.Empty, filters);
+
+            if (filters.Count == 0)
             {
-                filters.Add(Builders<BsonDocument>.Filter.Eq(element.Name, element.Value));
+                // Defensive fallback: match the document key elements as-is.
+                foreach (var element in documentKey.Elements)
+                {
+                    filters.Add(Builders<BsonDocument>.Filter.Eq(element.Name, element.Value));
+                }
             }
 
             return filters.Count == 1
                 ? filters[0]
                 : Builders<BsonDocument>.Filter.And(filters);
+        }
+
+        /// <summary>
+        /// Builds an equality filter that targets a single document by its <c>_id</c>.
+        /// When <paramref name="idValue"/> is an embedded document (a composite key), the
+        /// filter is flattened into dotted-path equality predicates (e.g. "_id.aggregatedChallengeId")
+        /// so that sharded collections whose shard key is a nested field can extract the shard key
+        /// for single-shard targeting on upsert/replace/delete.
+        /// </summary>
+        public static FilterDefinition<TDocument> BuildIdEqualityFilter<TDocument>(BsonValue idValue)
+        {
+            if (idValue != null && idValue.IsBsonDocument)
+            {
+                var nestedFilters = new List<FilterDefinition<TDocument>>();
+                AddEqualityFiltersFromDocument(idValue.AsBsonDocument, "_id", nestedFilters);
+
+                if (nestedFilters.Count > 0)
+                {
+                    return nestedFilters.Count == 1
+                        ? nestedFilters[0]
+                        : Builders<TDocument>.Filter.And(nestedFilters);
+                }
+            }
+
+            return Builders<TDocument>.Filter.Eq("_id", idValue);
+        }
+
+        // Flattens embedded documents (e.g. a composite _id) into dotted-path equality
+        // predicates. This is required for sharded collections whose shard key is a nested
+        // field such as { "_id.aggregatedChallengeId": "hashed" }: an equality match on the
+        // whole embedded _id document does not expose the nested value to mongos, so upsert /
+        // replace / delete fail with
+        // "An {upsert:true} update on a sharded collection must target a single shard".
+        // Matching every scalar leaf still uniquely identifies the document while surfacing
+        // the nested shard key.
+        private static void AddEqualityFiltersFromDocument<TDocument>(BsonDocument document, string prefix, List<FilterDefinition<TDocument>> filters)
+        {
+            foreach (var element in document.Elements)
+            {
+                var path = prefix.Length == 0 ? element.Name : $"{prefix}.{element.Name}";
+
+                if (element.Value.IsBsonDocument)
+                {
+                    AddEqualityFiltersFromDocument(element.Value.AsBsonDocument, path, filters);
+                }
+                else
+                {
+                    filters.Add(Builders<TDocument>.Filter.Eq(path, element.Value));
+                }
+            }
         }
 
 

--- a/OnlineMongoMigrationProcessor/Helpers/ParallelWriteHelper.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/ParallelWriteHelper.cs
@@ -48,27 +48,14 @@ namespace OnlineMongoMigrationProcessor.Helpers
             {
                 var fieldNames = documentKey.Names.ToArray();
                 MigrationJobContext.AddVerboseLog($"{_logPrefix}Cached filter builder for {collectionNamespace} with fields: [{string.Join(", ", fieldNames)}]");
-                
-                // Create optimized filter builder based on field count
-                if (fieldNames.Length == 1)
-                {
-                    // Single field optimization (most common - non-sharded)
-                    var fieldName = fieldNames[0];
-                    return (docKey) => Builders<BsonDocument>.Filter.Eq(fieldName, docKey[fieldName]);
-                }
-                else
-                {
-                    // Multiple fields - compound filter for sharded collections
-                    return (docKey) =>
-                    {
-                        var filters = new List<FilterDefinition<BsonDocument>>(fieldNames.Length);
-                        foreach (var fieldName in fieldNames)
-                        {
-                            filters.Add(Builders<BsonDocument>.Filter.Eq(fieldName, docKey[fieldName]));
-                        }
-                        return Builders<BsonDocument>.Filter.And(filters);
-                    };
-                }
+
+                // Delegate to the shared builder, which flattens embedded documents (e.g. a
+                // composite _id) into dotted-path equality predicates. This is required for
+                // sharded collections whose shard key is a nested field such as
+                // { "_id.aggregatedChallengeId": "hashed" }: an equality match on the whole
+                // embedded _id document hides the nested shard key from mongos, so upserts fail
+                // with "An {upsert:true} update on a sharded collection must target a single shard".
+                return (docKey) => MongoHelper.BuildFilterFromDocumentKey(docKey);
             });
         }
 

--- a/OnlineMongoMigrationProcessor/Processors/CollectionLevelChangeStreamProcessor.cs
+++ b/OnlineMongoMigrationProcessor/Processors/CollectionLevelChangeStreamProcessor.cs
@@ -1853,7 +1853,6 @@ namespace OnlineMongoMigrationProcessor
                     case ChangeStreamOperationType.Update:
                     case ChangeStreamOperationType.Replace:
                         IncrementEventCounter(mu, change.OperationType);
-                        var filter = Builders<BsonDocument>.Filter.Eq("_id", idValue);
                         if (!IsOptimizeForLargeDocsEnabled && (change.FullDocument == null || change.FullDocument.IsBsonNull))
                         {
                             // Without OFLD we use FullDocument:UpdateLookup, so a null body means the doc was

--- a/OnlineMongoMigrationProcessor/Processors/ServerLevelChangeStreamProcessor.cs
+++ b/OnlineMongoMigrationProcessor/Processors/ServerLevelChangeStreamProcessor.cs
@@ -1521,7 +1521,6 @@ namespace OnlineMongoMigrationProcessor
                     case ChangeStreamOperationType.Update:
                     case ChangeStreamOperationType.Replace:
                         IncrementEventCounter(mu, change.OperationType);
-                        var filter = Builders<BsonDocument>.Filter.Eq("_id", idValue);
                         if (!IsOptimizeForLargeDocsEnabled && (change.FullDocument == null || change.FullDocument.IsBsonNull))
                         {
                             // Without OFLD we use FullDocument:UpdateLookup, so a null body means the doc was
@@ -1531,7 +1530,9 @@ namespace OnlineMongoMigrationProcessor
                             if (!isWriteSimulated)
                             {
                                 _log.WriteLine($"{_syncBackPrefix}Processing {change.OperationType} operation for {collNameSpace} with _id {idValue}. No document found on source, deleting it from target.");
-                                var deleteTTLFilter = Builders<BsonDocument>.Filter.Eq("_id", idValue);
+                                // Flatten a composite (embedded) _id so sharded collections with a nested
+                                // shard key can target a single shard on the delete.
+                                var deleteTTLFilter = MongoHelper.BuildIdEqualityFilter<BsonDocument>(idValue);
                                 try
                                 {
                                     targetCollection.DeleteOne(deleteTTLFilter);


### PR DESCRIPTION
Change-stream replay/bulk writes built filters as an equality on the whole embedded _id document, which hides a nested shard key (e.g. {'_id.aggregatedChallengeId':'hashed'}) from mongos. Upserts then failed with 'An {upsert:true} update on a sharded collection must target a single shard'.

Flatten composite _id into dotted-path equality predicates in BuildFilterFromDocumentKey and a new BuildIdEqualityFilter<T> helper, and route all write paths (ParallelWriteHelper, AggressiveChangeStreamHelper, server-level TTL delete, replay) through them. Removed dead filter locals.