### PR TITLE
RU copy: resume-token-before-partitioning, gate PBRT logic,

### DIFF
--- a/MongoMigrationWebApp/Components/CollectionDetails.razor
+++ b/MongoMigrationWebApp/Components/CollectionDetails.razor
@@ -100,7 +100,7 @@
                                             <div><span class="lbl">Original Started On (UTC):</span> @MigrationUnit.GetOriginalChangeStreamStartedOn(false)?.ToString() <span class="text-muted">(rewound after stuck cursor)</span></div>
                                         }
                                         <div><span class="lbl">Start Resume Token:</span> @(MigrationUnit.GetOriginalResumeToken(false) ?? "N/A")</div>
-                                        <div><span class="lbl">Current Timestamp:</span> @MigrationUnit.GetCursorUtcTimestamp(false)</div>
+                                        <div><span class="lbl">Current Timestamp:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : MigrationUnit.GetCursorUtcTimestamp(false).ToString())</div>
                                         <div><span class="lbl">Current Resume Token:</span> @(MigrationUnit.GetResumeToken(false) ?? "N/A")</div>
                                         <div><span class="lbl">First Change Replayed:</span> @(string.IsNullOrEmpty(MigrationUnit.GetResumeDocumentKeyForDirection(false)) ? "N/A" : MigrationUnit.GetInitialDocumenReplayed(false).ToString())</div>
                                         <div><span class="lbl">First Change Document:</span> @(MigrationUnit.GetResumeDocumentKeyForDirection(false)?.ToString() ?? "N/A")</div>
@@ -112,7 +112,7 @@
                                         <div><span class="lbl">Failed (with retries):</span> @FormatLong(MigrationUnit.CSErrors)</div>
                                         <div><span class="lbl">Avg Read Latency (ms):</span> @MigrationUnit.CSAvgReadLatencyInMS.ToString("F2")</div>
                                         <div><span class="lbl">Avg Write Latency (ms):</span> @MigrationUnit.CSAvgWriteLatencyInMS.ToString("F2")</div>
-                                        <div><span class="lbl">Last Change UTC Time:</span> @(MigrationUnit.GetCSLastChangeUTCTime(false)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A")</div>
+                                        <div><span class="lbl">Last Change UTC Time:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : (MigrationUnit.GetCSLastChangeUTCTime(false)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A"))</div>
                                         <div><span class="lbl">Last Resume Token With Change:</span> @(MigrationUnit.GetCSLastResumeTokenWithChange(false) ?? "N/A")</div>
                                         @if (Helper.GetChangeStreamMode(MigrationJob) == "Aggressive" && MigrationUnit.AggressiveCacheDeleted)
                                         {
@@ -137,7 +137,7 @@
                                             <div><span class="lbl">Original Started On (UTC):</span> @MigrationUnit.GetOriginalChangeStreamStartedOn(true)?.ToString() <span class="text-muted">(rewound after stuck cursor)</span></div>
                                         }
                                         <div><span class="lbl">Start Resume Token:</span> @(MigrationUnit.GetOriginalResumeToken(true) ?? "N/A")</div>
-                                        <div><span class="lbl">Current Timestamp:</span> @MigrationUnit.GetCursorUtcTimestamp(true)</div>
+                                        <div><span class="lbl">Current Timestamp:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : MigrationUnit.GetCursorUtcTimestamp(true).ToString())</div>
                                         <div><span class="lbl">Current Resume Token:</span> @(MigrationUnit.GetResumeToken(true) ?? "N/A")</div>
                                         <div><span class="lbl">First Change Replayed:</span> @(string.IsNullOrEmpty(MigrationUnit.GetResumeDocumentKeyForDirection(true)) ? "N/A" : MigrationUnit.GetInitialDocumenReplayed(true).ToString())</div>
                                         <div><span class="lbl">First Change Document:</span> @(MigrationUnit.GetResumeDocumentKeyForDirection(true)?.ToString() ?? "N/A")</div>
@@ -147,7 +147,7 @@
                                         <div><span class="lbl">Updated:</span> @FormatLong(MigrationUnit.SyncBackDocsUpdated) (from @FormatLong(MigrationUnit.SyncBackUpdateEvents) events)</div>
                                         <div><span class="lbl">Duplicate Processed:</span> @FormatLong(MigrationUnit.SyncBackDuplicateDocsSkipped) skipped</div>
                                         <div><span class="lbl">Failed (with retries):</span> @FormatLong(MigrationUnit.SyncBackErrors)</div>
-                                        <div><span class="lbl">Last Change UTC Time:</span> @(MigrationUnit.GetCSLastChangeUTCTime(true)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A")</div>
+                                        <div><span class="lbl">Last Change UTC Time:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : (MigrationUnit.GetCSLastChangeUTCTime(true)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A"))</div>
                                         <div><span class="lbl">Last Resume Token With Change:</span> @(MigrationUnit.GetCSLastResumeTokenWithChange(true) ?? "N/A")</div>
                                     }
                                     else

--- a/MongoMigrationWebApp/Pages/JobReport.razor
+++ b/MongoMigrationWebApp/Pages/JobReport.razor
@@ -141,7 +141,7 @@ else
                     <div><span class="lbl">Mode:</span> @Helper.GetChangeStreamMode(MigrationJob)</div>
                     <div><span class="lbl">Started On (UTC):</span> @GetChangeStreamStartedOnForDisplay(mu, MigrationJob)</div>
                     <div><span class="lbl">Start Resume Token:</span> @(mu.GetOriginalResumeToken(false) ?? "N/A")</div>
-                    <div><span class="lbl">Current Timestamp:</span> @mu.GetCursorUtcTimestamp(false)</div>
+                    <div><span class="lbl">Current Timestamp:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : mu.GetCursorUtcTimestamp(false).ToString())</div>
                     <div><span class="lbl">Current Resume Token:</span> @(mu.GetResumeToken(false) ?? "N/A")</div>
                     <div><span class="lbl">First Change Replayed:</span> @(string.IsNullOrEmpty(mu.GetResumeDocumentKeyForDirection(false)) ? "N/A" : mu.GetInitialDocumenReplayed(false).ToString())</div>
                     <div><span class="lbl">First Change Document:</span> @(mu.GetResumeDocumentKeyForDirection(false)?.ToString() ?? "N/A")</div>
@@ -155,7 +155,7 @@ else
                     <div><span class="lbl">Failed (with retries):</span> @FormatLong(mu.CSErrors)</div>
                     <div><span class="lbl">Avg Read Latency (ms):</span> @mu.CSAvgReadLatencyInMS.ToString("F2")</div>
                     <div><span class="lbl">Avg Write Latency (ms):</span> @mu.CSAvgWriteLatencyInMS.ToString("F2")</div>
-                    <div><span class="lbl">Last Change UTC Time:</span> @(mu.GetCSLastChangeUTCTime(false)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A")</div>
+                    <div><span class="lbl">Last Change UTC Time:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : (mu.GetCSLastChangeUTCTime(false)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A"))</div>
                     <div><span class="lbl">Last Resume Token With Change:</span> @(mu.GetCSLastResumeTokenWithChange(false) ?? "N/A")</div>
                     @if (Helper.GetChangeStreamMode(MigrationJob) == "Aggressive" && mu.AggressiveCacheDeleted)
                     {
@@ -165,7 +165,7 @@ else
                 <td class="group-cell">
                     <div><span class="lbl">Started On (UTC):</span> @(mu.GetChangeStreamStartedOn(true)?.ToString() ?? "N/A")</div>
                     <div><span class="lbl">Start Resume Token:</span> @(mu.GetOriginalResumeToken(true) ?? "N/A")</div>
-                    <div><span class="lbl">Current Timestamp:</span> @mu.GetCursorUtcTimestamp(true)</div>
+                    <div><span class="lbl">Current Timestamp:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : mu.GetCursorUtcTimestamp(true).ToString())</div>
                     <div><span class="lbl">Current Resume Token:</span> @(mu.GetResumeToken(true) ?? "N/A")</div>
                     <div><span class="lbl">First Change Replayed:</span> @(string.IsNullOrEmpty(mu.GetResumeDocumentKeyForDirection(true)) ? "N/A" : mu.GetInitialDocumenReplayed(true).ToString())</div>
                     <div><span class="lbl">First Change Document:</span> @(mu.GetResumeDocumentKeyForDirection(true)?.ToString() ?? "N/A")</div>
@@ -177,7 +177,7 @@ else
                     <div><span class="lbl">Updated:</span> @FormatLong(mu.SyncBackDocsUpdated) (from @FormatLong(mu.SyncBackUpdateEvents) events)</div>
                     <div><span class="lbl">Duplicate Processed:</span> @FormatLong(mu.SyncBackDuplicateDocsSkipped) skipped</div>
                     <div><span class="lbl">Failed (with retries):</span> @FormatLong(mu.SyncBackErrors)</div>
-                    <div><span class="lbl">Last Change UTC Time:</span> @(mu.GetCSLastChangeUTCTime(true)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A")</div>
+                    <div><span class="lbl">Last Change UTC Time:</span> @(MigrationJob?.JobType == JobType.RUOptimizedCopy ? "N/A" : (mu.GetCSLastChangeUTCTime(true)?.ToString("yyyy-MM-dd HH:mm:ss") ?? "N/A"))</div>
                     <div><span class="lbl">Last Resume Token With Change:</span> @(mu.GetCSLastResumeTokenWithChange(true) ?? "N/A")</div>
                 </td>
                

--- a/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
@@ -662,7 +662,7 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
                         collection = database.GetCollection<BsonDocument>(collectionName);
 
                         // Initialize with safe defaults; will be overridden below
-                    
+                        
                         if (job.JobType == JobType.RUOptimizedCopy)
                         {
                             if (string.IsNullOrEmpty(mu.OriginalResumeToken))
@@ -875,19 +875,18 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
                     if (job.JobType == JobType.RUOptimizedCopy)
                     {
                         // Use linkedCts.Token instead of cts.Token to respect both timeout and manual cancellation
-                        if (await cursor.MoveNextAsync(linkedCts.Token))
-                        {
+                        //if (await cursor.MoveNextAsync(linkedCts.Token))
+                        //{
                             if (string.IsNullOrEmpty(mu.OriginalResumeToken))
                             {
                                 var resumeTokenJson = cursor.GetResumeToken().ToJson();
 
                                 mu.ResumeToken = resumeTokenJson;
                                 mu.OriginalResumeToken = resumeTokenJson;
-
                             }
                             return;
-                        }
-                        return;
+                        //}                       
+                        //return;
                     }
 
                     // Iterate until cancellation or first change detected

--- a/OnlineMongoMigrationProcessor/Processors/CollectionLevelChangeStreamProcessor.cs
+++ b/OnlineMongoMigrationProcessor/Processors/CollectionLevelChangeStreamProcessor.cs
@@ -1563,6 +1563,13 @@ namespace OnlineMongoMigrationProcessor
                                 SetResumeParameters(mu, stampTs, tokenJson, _syncBack);
                                 _consecutiveStuckRounds[collectionKey] = 0;
                             }
+                            else if (MigrationJobContext.CurrentlyActiveJob.JobType == JobType.RUOptimizedCopy)
+                            {
+                                // PBRT stuck-cursor detection and cluster-watch unblock are
+                                // MongoDB-specific workarounds and do not apply to Cosmos RU
+                                // change streams. Skip the stuck counting/enqueue for RU jobs so
+                                // the [PBRT] stuck/unblock logs never fire for them.
+                            }
                             else
                             {
                                 int stuck = _consecutiveStuckRounds.AddOrUpdate(collectionKey, 1, (_, v) => v + 1);

--- a/OnlineMongoMigrationProcessor/Workers/MigrationWorker.cs
+++ b/OnlineMongoMigrationProcessor/Workers/MigrationWorker.cs
@@ -600,7 +600,7 @@ namespace OnlineMongoMigrationProcessor.Workers
             }
         }
 
-        private async Task<TaskResult> SetCollectionResumeToken(MigrationUnit mu, bool syncBack, CancellationToken _cts, List<Task> resumeTokenTasks)
+        private async Task<TaskResult> SetCollectionResumeToken(MigrationUnit mu, bool syncBack, CancellationToken _cts, List<Task> resumeTokenTasks, bool runSynchronously = false)
         {
 #if LEGACY_MONGODB_DRIVER
             // Change stream resume tokens not supported with legacy MongoDB driver
@@ -619,43 +619,28 @@ namespace OnlineMongoMigrationProcessor.Workers
 
             _log.WriteLine($"Asynchronous resume token setup initiated ({durationSeconds}s timeout) for {mu.DatabaseName}.{mu.CollectionName}. Reset CS {mu.ResetChangeStream}", LogType.Debug);                
             string collectionKey = $"{mu.DatabaseName}.{mu.CollectionName}";
+
             try
             {
-                _log.WriteLine($"Calling SetChangeStreamResumeTokenAsync as async for {mu.DatabaseName}.{mu.CollectionName}", LogType.Debug);
-                var task = Task.Run(async () =>
+                if (runSynchronously)
                 {
-                    try
-                    {
-                        MongoClient mongoClient = new MongoClient();
-                        if(syncBack)
-                        {
-                            mongoClient= MongoClientFactory.Create(_log, MigrationJobContext.TargetConnectionString[MigrationJobContext.CurrentlyActiveJob.Id], false, string.Empty);
-                        }
-                        else
-                        {
-                            if(_sourceClient!=null)
-                            {
-                                mongoClient = _sourceClient!;
-                            }
-                            else
-                            {
-                                mongoClient= MongoClientFactory.Create(_log, MigrationJobContext.SourceConnectionString[MigrationJobContext.CurrentlyActiveJob.Id], false, string.Empty);
-                            }
+                    // RU copy: the change stream always starts from "now" (Cosmos RU cannot open a
+                    // change stream at a historical timestamp). Capture the resume token (open the
+                    // cursor) BEFORE partitioning/bulk copy begins, otherwise change events that
+                    // occur while the collection is being partitioned would be missed.
+                    _log.WriteLine($"Capturing resume token synchronously (before partitioning) for {mu.DatabaseName}.{mu.CollectionName}", LogType.Debug);
+                    await CaptureResumeTokenAsync(mu, syncBack, durationSeconds, _cts);
+                }
+                else
+                {
+                    _log.WriteLine($"Calling SetChangeStreamResumeTokenAsync as async for {mu.DatabaseName}.{mu.CollectionName}", LogType.Debug);
+                    var task = Task.Run(() => CaptureResumeTokenAsync(mu, syncBack, durationSeconds, _cts));
 
-                        }
-
-                        await MongoHelper.SetChangeStreamResumeTokenAsync(_log, mongoClient, MigrationJobContext.CurrentlyActiveJob, mu, durationSeconds, syncBack, _cts);
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.WriteLine($"Error in SetChangeStreamResumeTokenAsync for {mu.DatabaseName}.{mu.CollectionName}. Details: {ex}", LogType.Error);
-                    }
-                });
-                    
-                // Store task in dictionary by collection key
-                _resumeTokenTasksByCollection[collectionKey] = task;
-                // Also add to list for tracking
-                resumeTokenTasks.Add(task);
+                    // Store task in dictionary by collection key
+                    _resumeTokenTasksByCollection[collectionKey] = task;
+                    // Also add to list for tracking
+                    resumeTokenTasks.Add(task);
+                }
             }
             catch (Exception ex)
             {
@@ -666,6 +651,37 @@ namespace OnlineMongoMigrationProcessor.Workers
             return TaskResult.Success;
 #endif
         }
+
+#if !LEGACY_MONGODB_DRIVER
+        private async Task CaptureResumeTokenAsync(MigrationUnit mu, bool syncBack, int durationSeconds, CancellationToken _cts)
+        {
+            try
+            {
+                MongoClient mongoClient = new MongoClient();
+                if (syncBack)
+                {
+                    mongoClient = MongoClientFactory.Create(_log, MigrationJobContext.TargetConnectionString[MigrationJobContext.CurrentlyActiveJob.Id], false, string.Empty);
+                }
+                else
+                {
+                    if (_sourceClient != null)
+                    {
+                        mongoClient = _sourceClient!;
+                    }
+                    else
+                    {
+                        mongoClient = MongoClientFactory.Create(_log, MigrationJobContext.SourceConnectionString[MigrationJobContext.CurrentlyActiveJob.Id], false, string.Empty);
+                    }
+                }
+
+                await MongoHelper.SetChangeStreamResumeTokenAsync(_log, mongoClient, MigrationJobContext.CurrentlyActiveJob, mu, durationSeconds, syncBack, _cts);
+            }
+            catch (Exception ex)
+            {
+                _log.WriteLine($"Error in SetChangeStreamResumeTokenAsync for {mu.DatabaseName}.{mu.CollectionName}. Details: {ex}", LogType.Error);
+            }
+        }
+#endif
 
         private async Task<TaskResult> PreparePartitionsAsync(CancellationToken _cts, bool skipPartitioning)
         {
@@ -953,6 +969,16 @@ namespace OnlineMongoMigrationProcessor.Workers
 
                     if (!context.SkipPartitioning)
                     {
+                        // RU copy change streams always start from "now" (Cosmos RU cannot open a
+                        // change stream at a historical timestamp). Capture the resume token
+                        // synchronously BEFORE partitioning so change events that occur while the
+                        // collection is being partitioned/bulk-copied are not missed.
+                        if (MigrationJobContext.CurrentlyActiveJob.JobType == JobType.RUOptimizedCopy
+                            && Helper.IsOnline(MigrationJobContext.CurrentlyActiveJob))
+                        {
+                            await SetCollectionResumeToken(mu, MigrationJobContext.CurrentlyActiveJob.ProcessingSyncBack, _cts, new List<Task>(), runSynchronously: true);
+                        }
+
                         _log.WriteLine($"Creating partitions for {mu.DatabaseName}.{mu.CollectionName}", LogType.Debug);
                         var partResult = await CreatePartitionsAsync(mu, _cts);
                         if (partResult != TaskResult.Success)


### PR DESCRIPTION
Improvements to change-stream handling and monitoring for RU optimized copy (Azure Cosmos DB for MongoDB, RU) jobs.

Changes

- Resume token before partitioning — For RU copy jobs, SetChangeStreamResumeTokenAsync is now invoked (synchronously) before the collection is partitioned, in PrepareUnitForCopyAsync. RU change streams can only start from "now", so the resume token must be captured up front.
- Extract CaptureResumeTokenAsync — The nested local function was moved out into a private method for readability.
- Gate PBRT logic for RU jobs — MongoDB/Atlas-specific PBRT (postBatchResumeToken) stuck detection and cursor unblock logic is skipped for RU jobs, where it has no meaning (RU continuation tokens are opaque and carry no cluster/wall time).
- N/A timestamps in monitor — RU change events carry no ClusterTime/WallTime, so derived timestamps were showing the epoch 01/01/0001 00:00:00. For RU copy jobs, Current Timestamp and Last Change UTC Time now display N/A in both CollectionDetails and JobReport (forward and sync-back). Resume-token fields are left unchanged since those are meaningful for RU.