### PR TITLE
Fix mongo-tool TLS/connection-string handling, index-build monitor lo…

### DIFF
--- a/MongoMigrationWebApp/Components/ManageCollections.razor.cs
+++ b/MongoMigrationWebApp/Components/ManageCollections.razor.cs
@@ -299,7 +299,15 @@ namespace MongoMigrationWebApp.Components
             }
             catch (Exception ex)
             {
-                _error = $"Failed to resolve namespaces: {ex.Message}";
+                // Surface the full exception detail (including nested inner exceptions) so the root cause
+                // — e.g. an invalid source connection string / unreachable cluster — is visible to the user.
+                var details = new System.Text.StringBuilder();
+                for (var current = ex; current != null; current = current.InnerException)
+                {
+                    if (details.Length > 0) details.Append(" → ");
+                    details.Append(current.Message);
+                }
+                _error = $"Failed to resolve namespaces: {details}";
                 return;
             }
 

--- a/MongoMigrationWebApp/Shared/MainLayout.razor
+++ b/MongoMigrationWebApp/Shared/MainLayout.razor
@@ -12,7 +12,7 @@
                 <AuthorizeView>
                     <Authorized>
                         <div class="d-flex align-items-center gap-3">
-                            <div class="small">v0.9.8.1</div>
+                            <div class="small">v0.9.8.3</div>
                             <button class="btn btn-sm btn-outline-secondary" @onclick="@(() => Navigation.NavigateTo("/change-password"))">
                                 <i class="bi bi-key"></i> Change Password
                             </button>
@@ -22,7 +22,7 @@
                         </div>
                     </Authorized>
                     <NotAuthorized>
-                        <div class="small">v0.9.8.1</div>
+                        <div class="small">v0.9.8.3</div>
                     </NotAuthorized>
                 </AuthorizeView>
             </div>

--- a/OnlineMongoMigrationProcessor/Context/MigrationJobContext.cs
+++ b/OnlineMongoMigrationProcessor/Context/MigrationJobContext.cs
@@ -34,6 +34,11 @@ namespace OnlineMongoMigrationProcessor.Context
 
         private static Log _log;
 
+        // Read-only access to the initialized log so static helpers (e.g. namespace resolution
+        // in Helper/MongoHelper) can route MongoClient creation through MongoClientFactory, which
+        // needs a Log to report source-server certificate validation failures.
+        public static Log? Logger => _log;
+
         public static ActiveMigrationUnitsCache MigrationUnitsCache { get; set; }
 
         // Reference to the active MigrationProcessor (registered by MigrationWorker when a job starts).

--- a/OnlineMongoMigrationProcessor/Helpers/Helper.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/Helper.cs
@@ -169,6 +169,156 @@ namespace OnlineMongoMigrationProcessor
             );
         }
 
+        // Connection string CA-file options understood by the external mongo tools (mongodump/mongorestore).
+        // pemPath is the app's own custom option; the tools don't understand it, so it is always dropped.
+        private static readonly string[] MongoToolCaFileOptions = { "tlsCAFile", "sslCAFile", "pemPath" };
+        private static readonly object _toolCaFileLock = new object();
+
+        // URI TLS "insecure" options that the Go-based mongo tools frequently ignore when supplied in the
+        // connection string (especially when connecting by IP). Translating them to explicit CLI flags makes
+        // the tools honor them reliably. Maps the lower-cased URI option to its mongodump/mongorestore flag.
+        private static readonly (string UriOption, string ToolFlag)[] MongoToolInsecureTlsOptions =
+        {
+            ("tlsallowinvalidhostnames", "--sslAllowInvalidHostnames"),
+            ("tlsallowinvalidcertificates", "--sslAllowInvalidCertificates"),
+            ("tlsinsecure", "--tlsInsecure"),
+        };
+
+        /// <summary>
+        /// Result of normalizing a connection string for the external mongo tools: the URI to pass via --uri
+        /// plus any extra command-line flags that must be appended (TLS options the tools ignore in the URI).
+        /// </summary>
+        public sealed class MongoToolConnectionInfo
+        {
+            public string ConnectionString { get; set; } = string.Empty;
+            public string ExtraToolArguments { get; set; } = string.Empty;
+        }
+
+        /// <summary>
+        /// Normalizes a connection string for the external mongo tools (mongodump/mongorestore).
+        /// Three problems are handled:
+        ///  1. Default database in the path: the tools address databases/collections explicitly via
+        ///     --db / --nsFrom / --nsTo, and mongodump errors if the URI database differs from --db. The
+        ///     path database (e.g. /admin) is removed.
+        ///  2. CA file: the tools read tlsCAFile/sslCAFile from the URI and fail if the referenced file is
+        ///     missing. The .NET driver instead applies the CA from uploaded PEM contents via a validation
+        ///     callback, so a user-supplied CA path may not exist on the machine running the tools. When the
+        ///     referenced file is missing this repoints the option at a temp .pem materialized from
+        ///     <paramref name="caCertContents"/>, or removes the CA options entirely if no contents are available.
+        ///  3. Insecure TLS options: tlsAllowInvalidHostnames/tlsAllowInvalidCertificates/tlsInsecure are often
+        ///     ignored by the tools when set in the URI (notably when connecting by IP, whose cert has no IP
+        ///     SANs). Those are stripped from the URI and returned as explicit CLI flags instead.
+        /// </summary>
+        public static MongoToolConnectionInfo NormalizeConnectionStringForMongoTools(string connectionString, string? caCertContents)
+        {
+            var result = new MongoToolConnectionInfo { ConnectionString = connectionString };
+
+            if (string.IsNullOrWhiteSpace(connectionString))
+                return result;
+
+            var parts = connectionString.Split(new[] { '?' }, 2);
+            string baseConnStr = parts[0];
+            string queryString = parts.Length > 1 ? parts[1] : string.Empty;
+
+            bool modified = false;
+
+            // Remove any default database from the path (e.g. .../27017/admin -> .../27017/). The tools address
+            // databases/collections explicitly via --db / --nsFrom / --nsTo, and mongodump rejects a URI database
+            // that differs from the --db option ("Cannot specify different database in connection URI and command-line option").
+            string strippedBase = Regex.Replace(baseConnStr, @"^(mongodb(?:\+srv)?://[^/]+).*$", "$1/", RegexOptions.IgnoreCase);
+            if (!string.Equals(strippedBase, baseConnStr, StringComparison.Ordinal))
+            {
+                baseConnStr = strippedBase;
+                modified = true;
+            }
+
+            if (string.IsNullOrWhiteSpace(queryString))
+            {
+                if (modified)
+                    result.ConnectionString = baseConnStr;
+                return result;
+            }
+
+            // Preserve the original order and raw encoding of every option; the tools accept raw
+            // paths (with spaces/backslashes) inside a quoted --uri, so untouched options pass through verbatim.
+            var pairs = queryString
+                .Split('&')
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Select(p =>
+                {
+                    var kv = p.Split(new[] { '=' }, 2);
+                    return (Key: kv[0], Value: kv.Length > 1 ? kv[1] : string.Empty);
+                })
+                .ToList();
+
+            bool IsCaOption(string key) => MongoToolCaFileOptions.Any(n => string.Equals(n, key, StringComparison.OrdinalIgnoreCase));
+
+            // --- CA file handling ---
+            var caPair = pairs.FirstOrDefault(p => IsCaOption(p.Key));
+            if (caPair.Key != null && !(!string.IsNullOrWhiteSpace(caPair.Value) && File.Exists(caPair.Value)))
+            {
+                // Referenced CA file is missing: drop every CA option and re-add a valid tlsCAFile only if we
+                // can materialize the cert from the uploaded contents.
+                pairs = pairs.Where(p => !IsCaOption(p.Key)).ToList();
+                if (!string.IsNullOrWhiteSpace(caCertContents))
+                {
+                    string materializedPath = MaterializeMongoToolCaFile(caCertContents!);
+                    pairs.Add(("tlsCAFile", materializedPath));
+                }
+                modified = true;
+            }
+
+            // --- Insecure TLS option handling (translate URI option -> CLI flag) ---
+            var flags = new List<string>();
+            foreach (var (uriOption, toolFlag) in MongoToolInsecureTlsOptions)
+            {
+                var match = pairs.FirstOrDefault(p => string.Equals(p.Key, uriOption, StringComparison.OrdinalIgnoreCase));
+                if (match.Key != null && string.Equals(match.Value?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    pairs = pairs.Where(p => !string.Equals(p.Key, uriOption, StringComparison.OrdinalIgnoreCase)).ToList();
+                    flags.Add(toolFlag);
+                    modified = true;
+                }
+            }
+
+            if (modified)
+            {
+                var query = string.Join("&", pairs.Select(p => $"{p.Key}={p.Value}"));
+                result.ConnectionString = string.IsNullOrWhiteSpace(query) ? baseConnStr : $"{baseConnStr}?{query}";
+            }
+
+            if (flags.Count > 0)
+                result.ExtraToolArguments = " " + string.Join(" ", flags);
+
+            return result;
+        }
+
+        // Writes the CA cert contents to a stable file named by content hash so repeated calls (one per
+        // dump chunk) reuse the same file instead of littering the working folder with temp files.
+        private static string MaterializeMongoToolCaFile(string caCertContents)
+        {
+            string hash;
+            using (var sha = SHA256.Create())
+            {
+                var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(caCertContents));
+                hash = Convert.ToHexString(bytes).Substring(0, 16);
+            }
+
+            string dir = Path.Combine(GetWorkingFolder(), "toolcerts");
+            string filePath = Path.Combine(dir, $"{hash}.pem");
+
+            lock (_toolCaFileLock)
+            {
+                if (!File.Exists(filePath))
+                {
+                    Directory.CreateDirectory(dir);
+                    File.WriteAllText(filePath, caCertContents);
+                }
+            }
+
+            return filePath;
+        }
+
         public static string EncodeMongoPasswordInConnectionString(string connectionString)
         {
        
@@ -595,6 +745,21 @@ namespace OnlineMongoMigrationProcessor
         {
             MigrationJobContext.AddVerboseLog($"PopulateJobCollectionsAsync: jobId={job?.Id}");
 
+            // Wildcard/JSON namespace resolution hits the source cluster. Load the source CA (.pem)
+            // uploaded in Settings so the MongoClient trusts custom CAs (e.g. AWS DocumentDB); the
+            // .NET driver ignores tlsCAFile in the connection string, so this is the only way it works.
+            string pemFileContents = string.Empty;
+            try
+            {
+                var config = new MigrationSettings();
+                config.Load();
+                pemFileContents = config.CACertContentsForSourceServer ?? string.Empty;
+            }
+            catch
+            {
+                // Best-effort; fall back to no custom CA (publicly trusted source CAs still work).
+            }
+
             List<MigrationUnit> unitsToAdd = new List<MigrationUnit>();
             if (string.IsNullOrWhiteSpace(namespacesToMigrate))
             {
@@ -627,7 +792,7 @@ namespace OnlineMongoMigrationProcessor
                         ? sourceCollectionName
                         : item.TargetCollectionName.Trim();
 
-                    var tmpList = await PopulateJobCollectionsFromCSVAsync(job,$"{sourceDatabaseName}.{sourceCollectionName}", connectionString,false);
+                    var tmpList = await PopulateJobCollectionsFromCSVAsync(job,$"{sourceDatabaseName}.{sourceCollectionName}", connectionString,false, pemFileContents);
                     if (tmpList.Count > 0)
                     {
                         foreach (var mu in tmpList)
@@ -646,9 +811,7 @@ namespace OnlineMongoMigrationProcessor
             }
             else
             {
-                unitsToAdd = await PopulateJobCollectionsFromCSVAsync(job,namespacesToMigrate, connectionString);
-                
-                
+                unitsToAdd = await PopulateJobCollectionsFromCSVAsync(job,namespacesToMigrate, connectionString, true, pemFileContents);
             }
 
             foreach (var mu in unitsToAdd)
@@ -759,7 +922,7 @@ namespace OnlineMongoMigrationProcessor
             job.MigrationUnitBasics.Add(mu.GetBasic());
         }
 
-        private static async Task<List<MigrationUnit>> PopulateJobCollectionsFromCSVAsync(MigrationJob job,string namespacesToMigrate, string connectionString, bool split=true)
+        private static async Task<List<MigrationUnit>> PopulateJobCollectionsFromCSVAsync(MigrationJob job,string namespacesToMigrate, string connectionString, bool split=true, string? pemFileContents=null)
         {
             List<MigrationUnit> unitsToAdd = new List<MigrationUnit>();
 
@@ -795,10 +958,10 @@ namespace OnlineMongoMigrationProcessor
                 if (dbName == "*" && colName == "*")
                 {
                     // Get all databases and all collections from each database
-                    var databases = await MongoHelper.ListDatabasesAsync(connectionString);
+                    var databases = await MongoHelper.ListDatabasesAsync(connectionString, pemFileContents);
                     foreach (var database in databases)
                     {
-                        var collections = await MongoHelper.ListCollectionsAsync(connectionString, database);
+                        var collections = await MongoHelper.ListCollectionsAsync(connectionString, database, pemFileContents);
                         foreach (var collection in collections)
                         {
                             if (!unitsToAdd.Any(x => x.DatabaseName == database && x.CollectionName == collection))
@@ -812,10 +975,10 @@ namespace OnlineMongoMigrationProcessor
                 else if (dbName == "*" && colName != "*")
                 {
                     // Get all databases and find the specific collection in each
-                    var databases = await MongoHelper.ListDatabasesAsync(connectionString);
+                    var databases = await MongoHelper.ListDatabasesAsync(connectionString, pemFileContents);
                     foreach (var database in databases)
                     {
-                        var collections = await MongoHelper.ListCollectionsAsync(connectionString, database);
+                        var collections = await MongoHelper.ListCollectionsAsync(connectionString, database, pemFileContents);
                         if (collections.Contains(colName, StringComparer.OrdinalIgnoreCase))
                         {
                             if (!unitsToAdd.Any(x => x.DatabaseName == database && x.CollectionName == colName))
@@ -829,7 +992,7 @@ namespace OnlineMongoMigrationProcessor
                 else if (dbName != "*" && colName == "*")
                 {
                     // Get all collections from the specific database
-                    var collections = await MongoHelper.ListCollectionsAsync(connectionString, dbName);
+                    var collections = await MongoHelper.ListCollectionsAsync(connectionString, dbName, pemFileContents);
                     foreach (var collection in collections)
                     {
                         if (!unitsToAdd.Any(x => x.DatabaseName == dbName && x.CollectionName == collection))

--- a/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoClientFactory.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoClientFactory.cs
@@ -18,7 +18,7 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
         // to avoid exhausting logical sessions on the server (TooManyLogicalSessions)
         private static readonly ConcurrentDictionary<string, MongoClient> _clientCache = new();
 
-        public static MongoClient Create(Log log,string connectionString, bool ReadConcernMajority=false, string? PEMFileContents=null)
+        public static MongoClient Create(Log? log,string connectionString, bool ReadConcernMajority=false, string? PEMFileContents=null)
         {
             
             var cleanConnStr = RemovePemPathFromConnectionString(connectionString);
@@ -74,7 +74,7 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
             return string.IsNullOrWhiteSpace(newQuery) ? baseConnStr : $"{baseConnStr}?{newQuery}";
         }
 
-        private static RemoteCertificateValidationCallback ValidateAmazonDocDbCertificate(Log log,string pem)
+        private static RemoteCertificateValidationCallback ValidateAmazonDocDbCertificate(Log? log,string pem)
         {
             return (sender, certificate, chain, sslPolicyErrors) =>
             {
@@ -111,7 +111,7 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
                 }
                 catch (Exception ex)
                 {
-                    log.WriteLine($"Certificate validation failed: { ex}", LogType.Error);
+                    log?.WriteLine($"Certificate validation failed: { ex}", LogType.Error);
                     
                     return false;
                 }

--- a/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
+++ b/OnlineMongoMigrationProcessor/Helpers/Mongo/MongoHelper.cs
@@ -135,12 +135,15 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
 		/// </summary>
 		/// <param name="connectionString">MongoDB connection string</param>
 		/// <returns>List of database names, excluding system databases</returns>
-		public static async Task<List<string>> ListDatabasesAsync(string connectionString)
+		public static async Task<List<string>> ListDatabasesAsync(string connectionString, string? pemFileContents = null)
 		{
 			var databases = new List<string>();
 			try
 			{
-				var client = new MongoClient(connectionString);
+				// Route through the factory so the source CA (.pem uploaded in Settings) is applied via the
+				// custom certificate validation callback. The .NET driver ignores tlsCAFile in the connection
+				// string, so a bare "new MongoClient(connectionString)" cannot trust an AWS DocumentDB CA.
+				var client = MongoClientFactory.Create(MigrationJobContext.Logger, connectionString, false, pemFileContents);
 				var databasesCursor = await client.ListDatabasesAsync();
 				var databasesDocument = await databasesCursor.ToListAsync();
 
@@ -156,7 +159,10 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
 			}
 			catch (Exception)
 			{
-				// Return empty list if connection fails
+				// Re-throw so the caller (Add Collections UI) can surface the real cause (e.g. an
+				// invalid source connection string) instead of silently returning an empty list, which
+				// previously masked the failure as "no collections matched".
+				throw;
 			}
 			return databases;
 		}
@@ -167,12 +173,14 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
 		/// <param name="connectionString">MongoDB connection string</param>
 		/// <param name="databaseName">Database name</param>
 		/// <returns>List of collection names, excluding system collections, views, and other non-collection types</returns>
-		public static async Task<List<string>> ListCollectionsAsync(string connectionString, string databaseName)
+		public static async Task<List<string>> ListCollectionsAsync(string connectionString, string databaseName, string? pemFileContents = null)
 		{
 			var collections = new List<string>();
 			try
 			{
-				var client = new MongoClient(connectionString);
+				// Route through the factory so the source CA (.pem uploaded in Settings) is applied. See
+				// ListDatabasesAsync for why the raw connection string alone cannot trust an AWS DocumentDB CA.
+				var client = MongoClientFactory.Create(MigrationJobContext.Logger, connectionString, false, pemFileContents);
 				var database = client.GetDatabase(databaseName);
 				
 				// Get all collections (system collections will be filtered below)
@@ -197,7 +205,10 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
 			}
 			catch (Exception)
 			{
-				// Return empty list if connection fails
+				// Re-throw so the caller (Add Collections UI) can surface the real cause (e.g. an
+				// invalid source connection string) instead of silently returning an empty list, which
+				// previously masked the failure as "no collections matched".
+				throw;
 			}
 			return collections;
 		}
@@ -2600,7 +2611,10 @@ namespace OnlineMongoMigrationProcessor.Helpers.Mongo
             
             try
             {
-                var client = new MongoClient(connectionString);
+                // Route through the factory for connection reuse (avoids TooManyLogicalSessions) and so
+                // a source CA would be honored if this is ever called against a custom-CA source. Callers
+                // currently pass the target connection string, which uses a publicly trusted CA.
+                var client = MongoClientFactory.Create(MigrationJobContext.Logger, connectionString);
                 
                 // 1. vCore: db.adminCommand({ listShards: 1 }) -> { shards: [ { _id, host, ... } ], ok: 1 }
                 if (IsDocumentDBEndpoint(client))

--- a/OnlineMongoMigrationProcessor/Processors/MigrationProcessor.cs
+++ b/OnlineMongoMigrationProcessor/Processors/MigrationProcessor.cs
@@ -475,6 +475,14 @@ namespace OnlineMongoMigrationProcessor.Processors
                         return false;
                     }
 
+                    // Completion may have been flagged by the resume path or another monitor; stop polling
+                    // so we don't keep logging status after the build is already done.
+                    if (mu.IndexBuildComplete)
+                    {
+                        _log.WriteLine($"Blocking index build wait exiting for {namespaceForLog}: already marked complete", LogType.Debug);
+                        return true;
+                    }
+
                     // Use IndexesExpected as the denominator. IndexesMigrated may be 0 after a
                     // resume that skipped re-running createIndexes (target already has the index docs).
                     int denom = mu.IndexesExpected > 0 ? mu.IndexesExpected : mu.IndexesMigrated;
@@ -553,9 +561,18 @@ namespace OnlineMongoMigrationProcessor.Processors
                         stallChecks = 0;
                     }
 
-                    // Log every poll (~1 minute)
-                    _log.WriteLine($"Index build in progress for {namespaceForLog}: {activeBuilds} active, {progress:F1}% complete", LogType.Debug);
-                    _log.ShowInMonitor($"Index build in progress for {namespaceForLog}: {activeBuilds} active build(s), {progress:F1}% complete.");
+                    // Log every poll (~1 minute). With no active builds we're only confirming completion,
+                    // so avoid the misleading "in progress ... 100%" wording that contradicts the final status.
+                    if (activeBuilds > 0)
+                    {
+                        _log.WriteLine($"Index build in progress for {namespaceForLog}: {activeBuilds} active, {progress:F1}% complete", LogType.Debug);
+                        _log.ShowInMonitor($"Index build in progress for {namespaceForLog}: {activeBuilds} active build(s), {progress:F1}% complete.");
+                    }
+                    else
+                    {
+                        _log.WriteLine($"Verifying index build completion for {namespaceForLog}", LogType.Debug);
+                        _log.ShowInMonitor($"Verifying index build completion for {namespaceForLog}...");
+                    }
 
                     await Task.Delay(pollIntervalMs, _cts.Token);
                 }
@@ -580,7 +597,7 @@ namespace OnlineMongoMigrationProcessor.Processors
             const int pollIntervalMs = 60000;
             const int maxAttempts = 4320; // ~12 hours at 10s intervals
             const int maxStallChecks = 3; // unblock after repeated stalls so a failed build doesn't keep monitoring forever
-            bool seenAnyBuild = false;
+            int consecutiveZeroPolls = 0;
             int stallChecks = 0;
             int lastBuiltOnTarget = -1;
 
@@ -594,6 +611,14 @@ namespace OnlineMongoMigrationProcessor.Processors
                         return;
                     }
 
+                    // Completion may have been flagged by the resume path or another monitor; stop polling
+                    // so we don't keep logging status after the build is already done.
+                    if (mu.IndexBuildComplete)
+                    {
+                        _log.WriteLine($"Non-blocking index build monitor exiting for {namespaceForLog}: already marked complete", LogType.Debug);
+                        return;
+                    }
+
                     // Use IndexesExpected as the denominator. IndexesMigrated may be 0 after a
                     // resume that skipped re-running createIndexes (target already has the index docs).
                     int denom = mu.IndexesExpected > 0 ? mu.IndexesExpected : mu.IndexesMigrated;
@@ -601,7 +626,7 @@ namespace OnlineMongoMigrationProcessor.Processors
 
                     if (activeBuilds > 0)
                     {
-                        seenAnyBuild = true;
+                        consecutiveZeroPolls = 0;
                         stallChecks = 0;
                     }
 
@@ -612,62 +637,78 @@ namespace OnlineMongoMigrationProcessor.Processors
                     MigrationJobContext.SaveMigrationUnit(mu, true);
 
                     // activeBuilds < 0 = currentOp parse error; do not treat as complete.
-                    // activeBuilds == 0 with seenAnyBuild=false = warm-up window before queued ops appear; keep waiting.
-                    if (activeBuilds == 0 && seenAnyBuild)
+                    // Require two consecutive "no active build" polls before trusting the zero reading (queued
+                    // ops can momentarily report zero), then verify against the target. This also catches builds
+                    // that finish so fast no poll ever observes them active (otherwise the monitor would poll
+                    // until the 12h timeout while the UI already shows Success).
+                    if (activeBuilds == 0)
                     {
-                        // Verify with target listIndexes before flipping complete.
-                        int builtOnTarget = -1;
-                        try
+                        consecutiveZeroPolls++;
+                        if (consecutiveZeroPolls >= 2)
                         {
-                            var verifyClient = MongoClientFactory.Create(_log, targetConnStr);
-                            builtOnTarget = await Helpers.Mongo.IndexCopier.CountNonUniqueIndexesOnTargetAsync(verifyClient, databaseName, collectionName, _log);
-                        }
-                        catch { }
-                        if (mu.IndexesExpected <= 0 || (builtOnTarget >= 0 && builtOnTarget >= mu.IndexesExpected))
-                        {
-                            mu.IndexPercent = 100;
-                            mu.IndexBuildComplete = true;
-                            MigrationJobContext.SaveMigrationUnit(mu, true);
-                            _log.WriteLine($"Non-blocking index builds completed for {namespaceForLog}");
-                            _log.ShowInMonitor($"Index builds completed for {namespaceForLog} ({builtOnTarget}/{mu.IndexesExpected}).");
-                            return;
-                        }
-
-                        if (builtOnTarget >= 0)
-                        {
-                            if (builtOnTarget > lastBuiltOnTarget)
+                            // Verify with target listIndexes before flipping complete.
+                            int builtOnTarget = -1;
+                            try
                             {
-                                stallChecks = 0;
-                                lastBuiltOnTarget = builtOnTarget;
+                                var verifyClient = MongoClientFactory.Create(_log, targetConnStr);
+                                builtOnTarget = await Helpers.Mongo.IndexCopier.CountNonUniqueIndexesOnTargetAsync(verifyClient, databaseName, collectionName, _log);
                             }
-                            else
+                            catch { }
+                            if (mu.IndexesExpected <= 0 || (builtOnTarget >= 0 && builtOnTarget >= mu.IndexesExpected))
                             {
-                                stallChecks++;
-                            }
-
-                            if (mu.IndexesExpected > 0)
-                            {
-                                var partial = Math.Min(99, builtOnTarget * 100.0 / mu.IndexesExpected);
-                                mu.IndexPercent = Math.Max(mu.IndexPercent, partial);
-                                MigrationJobContext.SaveMigrationUnit(mu, true);
-                            }
-
-                            if (stallChecks >= maxStallChecks)
-                            {
-                                var failedCount = Math.Max(0, mu.IndexesExpected - builtOnTarget);
-                                _log.WriteLine($"Non-blocking index builds for {namespaceForLog} stalled at {builtOnTarget}/{mu.IndexesExpected} (no active builds, no progress for {maxStallChecks} checks). Ending monitor; any missing indexes must be created manually on the target.", LogType.Warning);
-                                _log.ShowInMonitor($"Index builds stalled for {namespaceForLog} at {builtOnTarget}/{mu.IndexesExpected}. {failedCount} index(es) may need to be created manually on the target.", LogType.Warning);
-                                mu.IndexesFailed = failedCount;
+                                mu.IndexPercent = 100;
                                 mu.IndexBuildComplete = true;
                                 MigrationJobContext.SaveMigrationUnit(mu, true);
+                                _log.WriteLine($"Non-blocking index builds completed for {namespaceForLog}");
+                                _log.ShowInMonitor($"Index builds completed for {namespaceForLog} ({builtOnTarget}/{mu.IndexesExpected}).");
                                 return;
+                            }
+
+                            if (builtOnTarget >= 0)
+                            {
+                                if (builtOnTarget > lastBuiltOnTarget)
+                                {
+                                    stallChecks = 0;
+                                    lastBuiltOnTarget = builtOnTarget;
+                                }
+                                else
+                                {
+                                    stallChecks++;
+                                }
+
+                                if (mu.IndexesExpected > 0)
+                                {
+                                    var partial = Math.Min(99, builtOnTarget * 100.0 / mu.IndexesExpected);
+                                    mu.IndexPercent = Math.Max(mu.IndexPercent, partial);
+                                    MigrationJobContext.SaveMigrationUnit(mu, true);
+                                }
+
+                                if (stallChecks >= maxStallChecks)
+                                {
+                                    var failedCount = Math.Max(0, mu.IndexesExpected - builtOnTarget);
+                                    _log.WriteLine($"Non-blocking index builds for {namespaceForLog} stalled at {builtOnTarget}/{mu.IndexesExpected} (no active builds, no progress for {maxStallChecks} checks). Ending monitor; any missing indexes must be created manually on the target.", LogType.Warning);
+                                    _log.ShowInMonitor($"Index builds stalled for {namespaceForLog} at {builtOnTarget}/{mu.IndexesExpected}. {failedCount} index(es) may need to be created manually on the target.", LogType.Warning);
+                                    mu.IndexesFailed = failedCount;
+                                    mu.IndexBuildComplete = true;
+                                    MigrationJobContext.SaveMigrationUnit(mu, true);
+                                    return;
+                                }
                             }
                         }
                     }
 
-                    // Log every poll (~1 minute)
-                    _log.WriteLine($"Index build in progress (non-blocking) for {namespaceForLog}: {activeBuilds} active, {progress:F1}% complete", LogType.Debug);
-                    _log.ShowInMonitor($"Index build in progress for {namespaceForLog}: {activeBuilds} active build(s), {progress:F1}% complete.");
+                    // Log every poll (~1 minute). With no active builds we're only confirming completion,
+                    // so avoid the misleading "in progress ... 100%" wording that contradicts the final status.
+                    if (activeBuilds > 0)
+                    {
+                        _log.WriteLine($"Index build in progress (non-blocking) for {namespaceForLog}: {activeBuilds} active, {progress:F1}% complete", LogType.Debug);
+                        _log.ShowInMonitor($"Index build in progress for {namespaceForLog}: {activeBuilds} active build(s), {progress:F1}% complete.");
+                    }
+                    else
+                    {
+                        _log.WriteLine($"Verifying index build completion (non-blocking) for {namespaceForLog}", LogType.Debug);
+                        _log.ShowInMonitor($"Verifying index build completion for {namespaceForLog}...");
+                    }
 
                     await Task.Delay(pollIntervalMs, _cts.Token);
                 }

--- a/OnlineMongoMigrationProcessor/Processors/MongoDumpRestoreCordinator.cs
+++ b/OnlineMongoMigrationProcessor/Processors/MongoDumpRestoreCordinator.cs
@@ -66,6 +66,10 @@ namespace OnlineMongoMigrationProcessor
         private string? _mongoRestoreToolPath;
         private string _processorRunId = string.Empty;
 
+        // Source CA cert contents (uploaded in settings) used to materialize a real CA file for the
+        // external mongo tools when the connection string references a CA path that doesn't exist locally.
+        private string? _sourceCaCertContents;
+
         private string _mongoDumpOutputFolder = Path.Combine(Helper.GetWorkingFolder(), "mongodump");
         private readonly SemaphoreSlim _uploadLock = new(1, 1);
 
@@ -391,6 +395,12 @@ namespace OnlineMongoMigrationProcessor
                     _onPendingTasksCompleted = onPendingTasksCompleted;
                     _processNewTasks = true;
                     _stopped = false;
+
+                    // Cache the uploaded source CA cert once so BuildDumpArgumentsAsync can materialize a real
+                    // CA file for the mongo tools when the source connection string points at a missing CA path.
+                    var caSettings = new MigrationSettings();
+                    caSettings.Load();
+                    _sourceCaCertContents = caSettings.CACertContentsForSourceServer;
 
                     // Resolve worker counts (use persisted value if set, otherwise auto-calculate)
                     int maxDumpWorkers, maxRestoreWorkers;
@@ -1556,6 +1566,13 @@ namespace OnlineMongoMigrationProcessor
             string colName)
         {
             MigrationJobContext.AddVerboseLog($"MongoDumpRestoreCordinator.BuildDumpArgumentsAsync: collection={dbName}.{colName}, chunkIndex={chunkIndex}");
+            // Repoint any missing CA file in the source connection string at a materialized temp cert (or
+            // strip it) so the external mongodump tool doesn't fail loading a CA path that only the .NET
+            // driver knows to ignore. Also translate insecure TLS URI options into explicit CLI flags the
+            // tools honor reliably (e.g. tlsAllowInvalidHostnames when connecting to DocumentDB by IP).
+            var sourceToolConn = Helper.NormalizeConnectionStringForMongoTools(sourceConnectionString, _sourceCaCertContents);
+            sourceConnectionString = sourceToolConn.ConnectionString;
+            string tlsToolArgs = sourceToolConn.ExtraToolArguments;
             // Build base dump arguments
             string args;
 
@@ -1569,6 +1586,8 @@ namespace OnlineMongoMigrationProcessor
             {
                 args = $" --uri={QuoteMongoToolArgument(sourceConnectionString)} --gzip --db={QuoteMongoToolArgument(dbName)} --collection={QuoteMongoToolArgument(colName)} --archive";
             }
+
+            args = $"{args}{tlsToolArgs}";
 
 
             // Build query and get doc count
@@ -2182,7 +2201,9 @@ namespace OnlineMongoMigrationProcessor
         private IMongoCollection<BsonDocument> GetSourceCollection(string sourceConnectionString, string dbName, string colName)
         {
             MigrationJobContext.AddVerboseLog($"MongoDumpRestoreCordinator.GetSourceCollection: database={dbName}, collection={colName}");
-            var sourceClient = MongoClientFactory.Create(_log, sourceConnectionString);
+            // Pass the uploaded source CA so the driver validates the chain via the custom callback instead
+            // of default validation, which fails for DocumentDB reached by IP (name mismatch + untrusted CA).
+            var sourceClient = MongoClientFactory.Create(_log, sourceConnectionString, false, _sourceCaCertContents);
             var sourceDb = sourceClient.GetDatabase(dbName);
             return sourceDb.GetCollection<BsonDocument>(colName);
         }
@@ -2429,8 +2450,13 @@ namespace OnlineMongoMigrationProcessor
             string targetCollectionName)
         {
             MigrationJobContext.AddVerboseLog($"MongoDumpRestoreCordinator.BuildRestoreArguments: source={sourceDatabaseName}.{sourceCollectionName}, target={targetDatabaseName}.{targetCollectionName}, chunkIndex={chunkIndex}");
+            // Strip a missing CA file path from the target connection string so mongorestore doesn't fail
+            // trying to load it (no target CA upload exists, so there's nothing to materialize). Also
+            // translate insecure TLS URI options into explicit CLI flags the tools honor reliably.
+            var targetToolConn = Helper.NormalizeConnectionStringForMongoTools(targetConnectionString, null);
+            targetConnectionString = targetToolConn.ConnectionString;
             // Always --noIndexRestore: collection + indexes are pre-created upfront so mongorestore stays a pure data path; lets every chunk run in parallel without index-build contention on the target.
-            string args = $" --uri={QuoteMongoToolArgument(targetConnectionString)} --gzip --archive --noIndexRestore";
+            string args = $" --uri={QuoteMongoToolArgument(targetConnectionString)} --gzip --archive --noIndexRestore{targetToolConn.ExtraToolArguments}";
             args = $"{args} --nsFrom={QuoteMongoToolArgument($"{sourceDatabaseName}.{sourceCollectionName}")} --nsTo={QuoteMongoToolArgument($"{targetDatabaseName}.{targetCollectionName}")}";
 
             //removed as we built indexes and collections earlier

--- a/OnlineMongoMigrationProcessor/Workers/MigrationWorker.cs
+++ b/OnlineMongoMigrationProcessor/Workers/MigrationWorker.cs
@@ -523,7 +523,15 @@ namespace OnlineMongoMigrationProcessor.Workers
                 MigrationJobContext.SaveMigrationJob(MigrationJobContext.CurrentlyActiveJob);
             }
 
-            mu.SetChangeStreamStartedOn(false, MigrationJobContext.CurrentlyActiveJob.ChangeStreamStartedOn.Value);
+            // Server-level jobs watch every collection through a single shared cursor, so each MU
+            // must anchor to the job's ChangeStreamStartedOn. Collection-level jobs open a per-collection
+            // cursor, so a collection added after the job started must anchor to when it was added (now),
+            // not the job's original start time. SetChangeStreamStartedOn is set-when-empty, so an existing
+            // per-collection anchor is preserved on resume.
+            if (useServerLevel)
+                mu.SetChangeStreamStartedOn(false, MigrationJobContext.CurrentlyActiveJob.ChangeStreamStartedOn.Value);
+            else
+                mu.SetChangeStreamStartedOn(false, DateTime.UtcNow);
            
 
             if (mu.MigrationChunks!=null && mu.MigrationChunks.Count>0)
@@ -2770,10 +2778,14 @@ namespace OnlineMongoMigrationProcessor.Workers
         {
             MigrationJobContext.AddVerboseLog($"CalculatePartitioningStrategy: docCount={documentCount}, db={databaseName}, coll={collectionName}, forceSkipDataTypeFilter={forceSkipDataTypeFilter}");
 
-            // Small collections under 1M docs: skip partitioning, process as a single chunk.
-            if (documentCount < 1_000_000)
+            // Small collections: skip partitioning, process as a single chunk. The 1M threshold
+            // scales with PartitionFactor (25-100%) so a lower factor (finer partitioning) also
+            // lowers the single-partition cutoff — e.g. factor 25 => 250K, factor 100 => 1M.
+            int singlePartitionFactor = Math.Min(100, Math.Max(25, _config!.PartitionFactor <= 0 ? 100 : _config!.PartitionFactor));
+            long singlePartitionThreshold = (long)(1_000_000L * (singlePartitionFactor / 100.0));
+            if (documentCount < singlePartitionThreshold)
             {
-                _log.WriteLine($"{databaseName}.{collectionName} has {documentCount} docs (< 1M). Skipping partitioning.", LogType.Debug);
+                _log.WriteLine($"{databaseName}.{collectionName} has {documentCount} docs (< {singlePartitionThreshold} threshold at PartitionFactor {singlePartitionFactor}%). Skipping partitioning.", LogType.Debug);
                 return (1, documentCount);
             }
 


### PR DESCRIPTION
…op, and change-stream anchoring

- NormalizeConnectionStringForMongoTools: strip default db from URI, materialize uploaded CA to a temp .pem and repoint tlsCAFile, and translate insecure-TLS URI options to mongodump/mongorestore CLI flags; source in-process driver now receives the CA contents.

- Non-blocking index-build monitor: mirror the blocking monitor's consecutiveZeroPolls verification so instant builds complete instead of logging '100%% complete' until timeout; both monitors exit early when IndexBuildComplete is already set.

- Partitioning: scale the single-partition (no-partition) cutoff by PartitionFactor so a lower factor also lowers the 1M threshold.

- Collection-level jobs now anchor a newly added collection's ChangeStreamStartedOn to when it was added (UtcNow) instead of the job's original start time; server-level jobs still inherit the shared cursor start.